### PR TITLE
Fix for finding sc-links with given content

### DIFF
--- a/server/sctp/client.py
+++ b/server/sctp/client.py
@@ -293,7 +293,7 @@ class SctpClient:
         for i in xrange(resCount):
             addr = ScAddr(0, 0)
             data = data[4:]
-            addr.seg, addr.offset = struct.unpack('=HH', data)
+            addr.seg, addr.offset = struct.unpack('=HH', data[:4])
             res.append(addr)
 
         return res


### PR DESCRIPTION
find_links_with_content() from python sctp client incorrectly handled sctp-server response with multiple sc-links. It also affect NL question-answering functionality